### PR TITLE
Fixed missing 'inline' modifier.

### DIFF
--- a/include/text_view_detail/character_set_info.hpp
+++ b/include/text_view_detail/character_set_info.hpp
@@ -92,6 +92,7 @@ get_character_set_info() {
     return *csi_ptr;
 }
 
+inline
 const character_set_info&
 get_character_set_info(
     character_set_id id)


### PR DESCRIPTION
Missing 'inline' in header file causes duplicate symbol error when get_character_set_info is used in multiple translation units.